### PR TITLE
Demonstrate bug with non-string header values.

### DIFF
--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "Users", type: :request do
   # Initialize test data.
   let!(:users) { create_list(:user, 10) }
   let(:user_id) { users.first.id }
-
+  let(:env) { }
+  
   # Test suite for POST /users.
   describe 'POST /users' do
     # Valid payload.
@@ -47,7 +48,7 @@ RSpec.describe "Users", type: :request do
 
   # Test suite for GET /users/{user_id}.
   describe 'GET /users/:id' do
-    before { get "/users/#{user_id}" }
+    before { get "/users/#{user_id}", env: env }
 
     context 'when the record exists' do
       it 'returns the user' do
@@ -70,6 +71,19 @@ RSpec.describe "Users", type: :request do
       it 'returns a not found message' do
         expect(response.body).to match(/Couldn't find User/)
       end
+    end
+
+    context 'when the header contain an integer' do
+      let(:user_id) { 1 }
+      let(:env) { { "HTTP_EXTRA_HEADER" => 75432 } }
+     
+      it 'returns status code 404' do
+        expect(response).to have_http_status(404)
+      end
+
+      it 'returns a not found message' do
+        expect(response.body).to match(/Couldn't find User/)
+      end       
     end
   end
 


### PR DESCRIPTION
This test demonstrates the bug fixed by https://github.com/akitasoftware/akita-rails-har-logger/pull/11

But, I cannot get a HAR file entry of the offending call when the test case succeeds, only when it fails, and I don't know why.
